### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/letanure/buildbase/security/code-scanning/4](https://github.com/letanure/buildbase/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow only needs to read the repository contents to run tests and upload artifacts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
