### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/letanure/buildbase/security/code-scanning/1](https://github.com/letanure/buildbase/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the `npx semantic-release` command likely requires `contents: write` to create releases and manage repository contents. We will set `contents: write` as the permission while ensuring no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
