### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/letanure/buildbase/security/code-scanning/3](https://github.com/letanure/buildbase/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), the minimal permissions required are `contents: read`. This ensures that the workflow has the least privilege necessary to complete its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
